### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/sync_secrets.yaml
+++ b/.github/workflows/sync_secrets.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Secrets
-        uses: google/secrets-sync-action@v1.7.1
+        uses: jpoehnelt/secrets-sync-action@v1.7.1
         with:
           dry_run: false
           secrets: |


### PR DESCRIPTION
This is a PR to update the action to the new repository location.\n\nNote GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.